### PR TITLE
Update DigaOkHttpClient.java to add contentType multipart request data

### DIFF
--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -111,7 +111,7 @@ public class DigaOkHttpClient implements DigaHttpClient {
                 RequestBody.create(
                     digaApiHttpRequest.getEncryptedContent(),
                     MediaType.parse("application/octet-stream")))
-           .build();
+            .build();
     return new Request.Builder().url(digaApiHttpRequest.getUrl()).post(body).build();
   }
 

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -110,7 +110,8 @@ public class DigaOkHttpClient implements DigaHttpClient {
                 "anfrage.cms",
                 RequestBody.create(
                     digaApiHttpRequest.getEncryptedContent(),
-                    MediaType.parse("application/octet-stream"))).build();
+                    MediaType.parse("application/octet-stream")))
+           .build();
     return new Request.Builder().url(digaApiHttpRequest.getUrl()).post(body).build();
   }
 

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -108,7 +108,7 @@ public class DigaOkHttpClient implements DigaHttpClient {
             .addFormDataPart(
                 "nutzdaten",
                 "anfrage.cms",
-                RequestBody.create(digaApiHttpRequest.getEncryptedContent()))
+                RequestBody.create(digaApiHttpRequest.getEncryptedContent(),MediaType.parse("application/octet-stream")))
             .build();
     return new Request.Builder().url(digaApiHttpRequest.getUrl()).post(body).build();
   }

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -108,8 +108,9 @@ public class DigaOkHttpClient implements DigaHttpClient {
             .addFormDataPart(
                 "nutzdaten",
                 "anfrage.cms",
-                RequestBody.create(digaApiHttpRequest.getEncryptedContent(),MediaType.parse("application/octet-stream")))
-            .build();
+                RequestBody.create(
+                    digaApiHttpRequest.getEncryptedContent(),
+                    MediaType.parse("application/octet-stream"))).build();
     return new Request.Builder().url(digaApiHttpRequest.getUrl()).post(body).build();
   }
 


### PR DESCRIPTION
# Pull Request

### Description
Set the MediaType of the encrypted content of the multipart request to "application/octet-stream".


### Closes
https://github.com/alex-therapeutics/diga-api-client/issues/147

