### PR TITLE
Add diga invoice correction

### DIFF
--- a/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
@@ -153,9 +153,9 @@ public final class DigaApiClient {
   }
 
   /**
-   * Send a test invoice correction to the specified insurance company. Note that currently the DiGA APIs do
-   * not seem to respond with 'valid' to test requests, even using valid test codes. If you are
-   * successful, you will receive a response which validated all the XML schemas, but it has an
+   * Send a test invoice correction to the specified insurance company. Note that currently the DiGA
+   * APIs do not seem to respond with 'valid' to test requests, even using valid test codes. If you
+   * are successful, you will receive a response which validated all the XML schemas, but it has an
    * error like "could not find the code".
    *
    * @param invoice - the corrected invoice to send
@@ -293,10 +293,9 @@ public final class DigaApiClient {
       DigaInvoice invoice, DigaBillingInformation billingInformation, DigaProcessCode processCode)
       throws DigaXmlWriterException {
     var xmlInvoice =
-            invoice instanceof DigaCorrectionInvoice correctionInvoice
-                    ? xmlRequestWriter.createInvoiceCorrectionRequest(
-                    correctionInvoice, billingInformation)
-                    : xmlRequestWriter.createBillingRequest(invoice, billingInformation);
+        invoice instanceof DigaCorrectionInvoice correctionInvoice
+            ? xmlRequestWriter.createInvoiceCorrectionRequest(correctionInvoice, billingInformation)
+            : xmlRequestWriter.createBillingRequest(invoice, billingInformation);
     if (!billingInformation.getBuyerInvoicingMethod().equals(DigaInvoiceMethod.API)) {
       return buildManualInvoicingResponse(billingInformation, xmlInvoice);
     }

--- a/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
@@ -127,11 +127,45 @@ public final class DigaApiClient {
     return performDigaInvoicing(invoice, billingInformation, DigaProcessCode.BILLING);
   }
 
+  /**
+   * Send an Invoice correction for a DiGA prescription.
+   *
+   * @param invoice - individual corrected invoice details
+   * @return An object containing details on the response to the invoice request, the generated
+   *     invoice itself, as well as request details such as which insurance company was sent to,
+   *     which endpoint, IK, etc. This response may contain errors, in which case there are error
+   *     messages in the object.
+   *     <p>You can check that the invoice request succeeded by checking if (response.hasError())
+   *     {}. If hasError is false, the invoice was successful.
+   *     <p>You should check {@link DigaInvoiceResponse#isRequiresManualAction()} to see whether the
+   *     invoice needs to be handled manually, in the cases when the target insurance company does
+   *     not support sending invoices via the API.
+   *     <p>The contents of the Invoice itself is located in {@link
+   *     DigaInvoiceResponse#getGeneratedInvoice()}, you can fetch that and use it for accounting
+   *     needs both when invoicing was successful and when it was not.
+   * @throws DigaCodeValidationException if given an invalid DiGA code
+   * @throws DigaXmlWriterException if we fail to create the XML request body (the XRechnung
+   *     invoice)
+   */
   public DigaInvoiceResponse digaInvoiceCorrection(DigaCorrectionInvoice invoice)
       throws DigaCodeValidationException, DigaXmlWriterException {
     return this.invoiceDiga(invoice);
   }
 
+  /**
+   * Send a test invoice correction to the specified insurance company. Note that currently the DiGA APIs do
+   * not seem to respond with 'valid' to test requests, even using valid test codes. If you are
+   * successful, you will receive a response which validated all the XML schemas, but it has an
+   * error like "could not find the code".
+   *
+   * @param invoice - the corrected invoice to send
+   * @param insuranceCompanyPrefix - the prefix of the company to send it to, as listed in the
+   *     insurance company mapping file
+   * @return An object containing details on the response as well as the request details. See
+   *     'digaInvoiceCorrection' method.
+   * @throws DigaXmlWriterException if we fail to create the XML request body (the XRechnung
+   *     invoice)
+   */
   public DigaInvoiceResponse digaTestInvoiceCorrection(
       DigaCorrectionInvoice invoice, String insuranceCompanyPrefix) throws DigaXmlWriterException {
     return this.sendTestInvoiceRequest(invoice, insuranceCompanyPrefix);
@@ -259,11 +293,10 @@ public final class DigaApiClient {
       DigaInvoice invoice, DigaBillingInformation billingInformation, DigaProcessCode processCode)
       throws DigaXmlWriterException {
     var xmlInvoice =
-        invoice instanceof DigaCorrectionInvoice
-            ? xmlRequestWriter.createInvoiceCorrectionRequest(
-                (DigaCorrectionInvoice) invoice, billingInformation)
-            : xmlRequestWriter.createBillingRequest(invoice, billingInformation);
-
+            invoice instanceof DigaCorrectionInvoice correctionInvoice
+                    ? xmlRequestWriter.createInvoiceCorrectionRequest(
+                    correctionInvoice, billingInformation)
+                    : xmlRequestWriter.createBillingRequest(invoice, billingInformation);
     if (!billingInformation.getBuyerInvoicingMethod().equals(DigaInvoiceMethod.API)) {
       return buildManualInvoicingResponse(billingInformation, xmlInvoice);
     }

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
@@ -20,6 +20,7 @@ package com.alextherapeutics.diga;
 
 import com.alextherapeutics.diga.model.DigaBillingInformation;
 import com.alextherapeutics.diga.model.DigaCodeInformation;
+import com.alextherapeutics.diga.model.DigaCorrectionInvoice;
 import com.alextherapeutics.diga.model.DigaInvoice;
 
 /** Creates raw XML data bodies containing code validation requests or DiGA invoices. */
@@ -44,5 +45,18 @@ public interface DigaXmlRequestWriter {
    * @throws DigaXmlWriterException - if the request body couldn't be created
    */
   byte[] createBillingRequest(DigaInvoice invoice, DigaBillingInformation billingInformation)
+      throws DigaXmlWriterException;
+
+  /**
+   * Create a XML request body containing a DiGA correction invoice (an "XRechnung" invoice
+   * conforming to UN/CEFACT standard)
+   *
+   * @param correctionInvoice - information required to create the invoice
+   * @param billingInformation - information on the buyer
+   * @return A byte array containing a (non-encrypted) XRechnung XML invoice
+   * @throws DigaXmlWriterException - if the request body couldn't be created
+   */
+  byte[] createInvoiceCorrectionRequest(
+      DigaCorrectionInvoice correctionInvoice, DigaBillingInformation billingInformation)
       throws DigaXmlWriterException;
 }

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
@@ -214,7 +214,7 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
     if (digaCorrectionInvoice.getCorrectionCodeReason() != null
         && digaCorrectionInvoice.getCorrectionCodeReason().length > 0) {
       correctionCode += ":";
-      correctionCode += String.join("+", digaCorrectionInvoice.getCorrectionCodeReason());
+      correctionCode += String.join("+", digaCorrectionInvoice.getCorrectionCode());
     }
     textType.setValue(correctionCode);
     var noteType = billingObjectFactory.createNoteType();

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriter.java
@@ -129,6 +129,28 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
     }
   }
 
+  @Override
+  public byte[] createInvoiceCorrectionRequest(
+      DigaCorrectionInvoice digaCorrectionInvoice, DigaBillingInformation billingInformation)
+      throws DigaXmlWriterException {
+    try {
+
+      var invoice = billingObjectFactory.createCrossIndustryInvoiceType();
+      invoice.setExchangedDocumentContext(createExchangedDocumentContext());
+      invoice.setExchangedDocument(createInvoiceCorrectionExchangedDocument(digaCorrectionInvoice));
+      invoice.setSupplyChainTradeTransaction(
+          createInvoiceCorrectionSupplyChainTradeTransaction(
+              digaCorrectionInvoice, billingInformation));
+      var root = billingObjectFactory.createCrossIndustryInvoice(invoice);
+      try (var res = new ByteArrayOutputStream()) {
+        billingMarshaller.marshal(root, res);
+        return res.toByteArray();
+      }
+    } catch (JAXBException | IOException e) {
+      throw new DigaXmlWriterException(e);
+    }
+  }
+
   private void init() throws JAXBException {
     datatypeFactory = DatatypeFactory.newDefaultInstance();
 
@@ -173,6 +195,36 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
     return exchangedDocument;
   }
 
+  // metadata for the document
+  private ExchangedDocumentType createInvoiceCorrectionExchangedDocument(
+      DigaCorrectionInvoice digaCorrectionInvoice) {
+    // ExchangedDocument
+    var exchangedDocument = billingObjectFactory.createExchangedDocumentType();
+    exchangedDocument.setID(
+        createIdType(
+            digaCorrectionInvoice
+                .getInvoiceId())); // pretty sure this is an invoice id/number, so we set it
+    // ourselves but must be unique
+    var typeCode = billingObjectFactory.createDocumentCodeType();
+    typeCode.setValue("384"); // should always be 384 here, means "invoice correction"
+    exchangedDocument.setTypeCode(typeCode);
+
+    var textType = billingObjectFactory.createTextType();
+    var correctionCode = digaCorrectionInvoice.getCorrectionCode();
+    if (digaCorrectionInvoice.getCorrectionCodeReason() != null
+        && digaCorrectionInvoice.getCorrectionCodeReason().length > 0) {
+      correctionCode += ":";
+      correctionCode += String.join("+", digaCorrectionInvoice.getCorrectionCodeReason());
+    }
+    textType.setValue(correctionCode);
+    var noteType = billingObjectFactory.createNoteType();
+    noteType.getContent().add(textType);
+    exchangedDocument.getIncludedNote().add(noteType);
+
+    exchangedDocument.setIssueDateTime(createDateTime(digaCorrectionInvoice.getIssueDate()));
+    return exchangedDocument;
+  }
+
   // the data of the actual transaction being invoiced
   private SupplyChainTradeTransactionType createSupplyChainTradeTransaction(
       DigaInvoice digaInvoice, DigaBillingInformation billingInformation) {
@@ -185,6 +237,38 @@ public class DigaXmlJaxbRequestWriter implements DigaXmlRequestWriter {
     transaction.setApplicableHeaderTradeDelivery(createApplicableHeaderTradeDelivery(digaInvoice));
     transaction.setApplicableHeaderTradeSettlement(
         createApplicableHeaderTradeSettlement(digaInvoice));
+    return transaction;
+  }
+
+  // the data of the actual transaction being invoiced
+  private SupplyChainTradeTransactionType createInvoiceCorrectionSupplyChainTradeTransaction(
+      DigaCorrectionInvoice digaCorrectionInvoice, DigaBillingInformation billingInformation) {
+    var transaction = billingObjectFactory.createSupplyChainTradeTransactionType();
+    var invoice =
+        DigaInvoice.builder()
+            .invoiceId(digaCorrectionInvoice.getInvoiceId())
+            .validatedDigaCode(digaCorrectionInvoice.getValidatedDigaCode())
+            .digavEid(digaCorrectionInvoice.getDigavEid())
+            .dateOfServiceProvision(digaCorrectionInvoice.getDateOfServiceProvision())
+            .issueDate(digaCorrectionInvoice.getIssueDate())
+            .invoiceCurrencyCode(digaCorrectionInvoice.getInvoiceCurrencyCode())
+            .build();
+    transaction
+        .getIncludedSupplyChainTradeLineItem()
+        .add(createIncludedSupplyChainTradeItem(invoice));
+    transaction.setApplicableHeaderTradeAgreement(
+        createApplicableHeaderTradeAgreement(invoice, billingInformation));
+    transaction.setApplicableHeaderTradeDelivery(createApplicableHeaderTradeDelivery(invoice));
+
+    var applicableHeaderTradeSettlement = createApplicableHeaderTradeSettlement(invoice);
+    if (digaCorrectionInvoice.getReferenceInvoiceId() != null) {
+      var invoiceReferencedDocument = billingObjectFactory.createReferencedDocumentType();
+      invoiceReferencedDocument.setIssuerAssignedID(
+          createIdType(digaCorrectionInvoice.getReferenceInvoiceId()));
+      applicableHeaderTradeSettlement.setInvoiceReferencedDocument(invoiceReferencedDocument);
+    }
+    transaction.setApplicableHeaderTradeSettlement(applicableHeaderTradeSettlement);
+
     return transaction;
   }
 

--- a/src/main/java/com/alextherapeutics/diga/model/DigaCorrectionInvoice.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaCorrectionInvoice.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2021 Alex Therapeutics AB and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.alextherapeutics.diga.model;
+
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/** A DiGA correction invoice request */
+@Builder
+@Getter
+public class DigaCorrectionInvoice {
+  /**
+   * The ID of the corrected invoice. You set this to something unique which fits with your billing
+   * system.
+   */
+  @NonNull private final String invoiceId;
+
+  /**
+   * The ID of the reference invoice. You set this to the original invoice id to reference it in
+   * your billing system.
+   */
+  private final String referenceInvoiceId;
+
+  /** The invoice issue date. Defaults to now() */
+  @Builder.Default private final Date issueDate = new Date();
+
+  /** The DiGA code you are charging for. */
+  @NonNull private final String validatedDigaCode;
+
+  /** Date of service provision "Tag der Leistungserbringung" */
+  @NonNull private final Date dateOfServiceProvision;
+
+  /**
+   * The DiGAVEid that was validated by this code. You will find this in the response to the code
+   * validation request at {@link DigaCodeValidationResponse#getValidatedDigaveid()}
+   */
+  @NonNull private final String digavEid;
+
+  @Builder.Default private final String invoiceCurrencyCode = "EUR";
+
+  @NonNull private final String correctionCode;
+
+  private final String[] correctionCodeReason;
+}

--- a/src/main/java/com/alextherapeutics/diga/model/DigaCorrectionInvoice.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaCorrectionInvoice.java
@@ -18,43 +18,19 @@
 
 package com.alextherapeutics.diga.model;
 
-import java.util.Date;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 
 /** A DiGA correction invoice request */
-@Builder
+@SuperBuilder
 @Getter
-public class DigaCorrectionInvoice {
-  /**
-   * The ID of the corrected invoice. You set this to something unique which fits with your billing
-   * system.
-   */
-  @NonNull private final String invoiceId;
-
+public class DigaCorrectionInvoice extends DigaInvoice {
   /**
    * The ID of the reference invoice. You set this to the original invoice id to reference it in
    * your billing system.
    */
   private final String referenceInvoiceId;
-
-  /** The invoice issue date. Defaults to now() */
-  @Builder.Default private final Date issueDate = new Date();
-
-  /** The DiGA code you are charging for. */
-  @NonNull private final String validatedDigaCode;
-
-  /** Date of service provision "Tag der Leistungserbringung" */
-  @NonNull private final Date dateOfServiceProvision;
-
-  /**
-   * The DiGAVEid that was validated by this code. You will find this in the response to the code
-   * validation request at {@link DigaCodeValidationResponse#getValidatedDigaveid()}
-   */
-  @NonNull private final String digavEid;
-
-  @Builder.Default private final String invoiceCurrencyCode = "EUR";
 
   @NonNull private final String correctionCode;
 

--- a/src/main/java/com/alextherapeutics/diga/model/DigaInvoice.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaInvoice.java
@@ -22,9 +22,10 @@ import java.util.Date;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 
 /** A DiGA invoice request */
-@Builder
+@SuperBuilder
 @Getter
 public class DigaInvoice {
   /**


### PR DESCRIPTION
# Pull Request

### Description
This PR (WIP in order to gather more feedback) adds the possibility to send diga invoice corrections  as described in "Technische Anlage 1" https://www.gkv-datenaustausch.de/media/dokumente/leistungserbringer_1/digitale_gesundheitsanwendungen/technische_anlagen_aktuell_7/DiGA_Anlage_1_Technische_Anlage_zur_RL_V2.0_20230510.pdf and "Anhang 8" https://www.gkv-datenaustausch.de/media/dokumente/leistungserbringer_1/digitale_gesundheitsanwendungen/technische_anlagen_archiv_8/DiGA_Anhang8_Rechnungskorrekturen_V1.1.0_20230413.pdf

The idea is to have a separate class (similiar to DigaInvoice) in order to not interfere with the existing implementation.
In the DigaApiClient two new methods (digaInvoiceCorrection and digaTestInvoiceCorrection) are exposed that take the DigaCorrectionInvoice class as a parameter.
The request payload is build inside DigaXmlJaxbRequestWriter and is reusing as much functions as possible from the existing implementation for billing.

Feel free to share ideas / opinions / feedback regarding the current state of the implementation

### Open

- Tests

